### PR TITLE
Update ctags executable and related vim plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Backup your .vim and .vimrc settings and clone repo to ~/.vim
 $ git clone git@github.com:misakwa/dotvim.git ~/.vim
 ```
 
-Install exuberant-ctags ( Depends on your OS ) - easy to find some information on google
+Install [Universal Ctags](https://github.com/universal-ctags/ctags)
+
+* [Mac Homebrew install instructions](https://github.com/universal-ctags/homebrew-universal-ctags)
 
 Run the bootstrap script.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,13 @@
 # Update submodule to retrieve neobundle
 git submodule update --init --recursive
 
-# Link vimrc
-rm $HOME/.vimrc
+# Backup .vimrc
+if [ -f $HOME/.vimrc ]; then
+    backup_file=$HOME/.vimrc-backup-$(date +%s)
+    echo "Copying contents of $HOME/.vimrc to $backup_file"
+    cp -L $HOME/.vimrc $backup_file
+fi
+
+# Link .vimrc
+rm -f $HOME/.vimrc
 ln -s $HOME/.vim/vimrc $HOME/.vimrc

--- a/neobundles.vim
+++ b/neobundles.vim
@@ -58,7 +58,7 @@ NeoBundle 'zhaocai/GoldenView.Vim'
 
 if executable('ctags')
     NeoBundle 'majutsushi/tagbar'
-    NeoBundle 'xolox/vim-easytags'
+    NeoBundle 'ludovicchabant/vim-gutentags'
     NeoBundle 'xolox/vim-misc'
 endif
 

--- a/vimrc
+++ b/vimrc
@@ -123,18 +123,7 @@ let g:SuperTabContextDefaultCompletionType = '<c-x><c-o>'
 let g:SuperTabContextDiscoverDiscovery = ["&omnifunc:<c-x><c-o>","&completefunc:<c-x><c-u>"]
 
 set tags=./.tags,./tags,./.vimtags,tags,vimtags
-let g:easytags_async = 1
-let g:easytags_python_enabled = 1
-let g:easytags_dynamic_files = 2
-" let g:easytags_python_languages = {
-"         \   'php': {
-"         \       'cmd': g:easytags_cmd,
-"         \       'args': []
-"         \
-"         \
-"         \
-"         \   }
-" }
+let g:gutentags_ctags_tagfile = '.tags'
 
 let g:arline_powerline_fonts = 0
 let g:airline#extensions#tmuxline#enabled = 0
@@ -197,7 +186,8 @@ set statusline+=%#identifier#
 set statusline+=%m
 set statusline+=%*
 
-set statusline+=%{fugitive#statusline()}
+"Lazy load fugitive statusline if plugin installed
+set statusline+=%{exists('g:loaded_fugitive')?fugitive#statusline():''}
 
 "display a warning if &et is wrong, or we have mixed-indenting
 set statusline+=%#error#
@@ -209,7 +199,9 @@ set statusline+=%{StatuslineTrailingSpaceWarning()}
 set statusline+=%{StatuslineLongLineWarning()}
 
 set statusline+=%#warningmsg#
-set statusline+=%{SyntasticStatuslineFlag()}
+
+"Lazy load SyntasticStatusLine if plugin installed
+set statusline+=%{exists('g:loaded_syntastic_plugin')?SyntasticStatuslineFlag():''}
 set statusline+=%*
 
 "display a warning if &paste is set
@@ -381,6 +373,7 @@ nnoremap <f4> :GundoToggle<cr>
 
 let g:gundo_width = 60
 let g:gundo_preview_height = 100
+let g:gundo_prefer_python3 = 1
 "let g:gundo_right = 1
 "let g:gundo_preview_bottom = 1
 "let g:gundo_preview_statusline = 1


### PR DESCRIPTION
 - Replace the decade old, unmaintained Exuberant Ctags with the current
   and actively maintained Universal Ctags
 - Replace old and unmaintained vim-easytags with vim-gutentags
 - Update .vimrc for above ctags/gutentags changes
 - On first install, NeoBundle can't successfully install required
   pluggins because the .vimrc expects those plugins to be present.
   Update .vimrc to lazyload some status lines if the plugin is present